### PR TITLE
Remove unsupported hashes

### DIFF
--- a/creds3.py
+++ b/creds3.py
@@ -51,8 +51,8 @@ _hash_classes = {
     'SHA256': hashes.SHA256,
     'SHA384': hashes.SHA384,
     'SHA512': hashes.SHA512,
-    'RIPEMD': hashes.RIPEMD160,
-    'WHIRLPOOL': hashes.Whirlpool,
+    # 'RIPEMD': hashes.RIPEMD160,
+    # 'WHIRLPOOL': hashes.Whirlpool,
     'MD5': hashes.MD5,
 }
 


### PR DESCRIPTION
Two hashes were no longer supported by the latest crytography package. It's causing error when importing creds3. 